### PR TITLE
iox-#2128 Add a name to the `MePooSegment` data structure and allow m…

### DIFF
--- a/iceoryx_posh/include/iceoryx_posh/error_handling/error_handling.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/error_handling/error_handling.hpp
@@ -1,5 +1,6 @@
 // Copyright (c) 2019 - 2020 by Robert Bosch GmbH. All rights reserved.
 // Copyright (c) 2020 - 2022 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2024 by Latitude AI. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -111,9 +112,9 @@ namespace iox
     error(MEPOO__MEMPOOL_GETCHUNK_POOL_IS_RUNNING_OUT_OF_CHUNKS) \
     error(MEPOO__MEMPOOL_CHUNKSIZE_MUST_BE_MULTIPLE_OF_CHUNK_MEMORY_ALIGNMENT) \
     error(MEPOO__MEMPOOL_ADDMEMPOOL_AFTER_GENERATECHUNKMANAGEMENTPOOL) \
+    error(MEPOO__MULTIPLE_SEGMENT_CONFIG_ENTRIES_WITH_SAME_NAME) \
     error(MEPOO__TYPED_MEMPOOL_HAS_INCONSISTENT_STATE) \
     error(MEPOO__TYPED_MEMPOOL_MANAGEMENT_SEGMENT_IS_BROKEN) \
-    error(MEPOO__USER_WITH_MORE_THAN_ONE_WRITE_SEGMENT) \
     error(MEPOO__SEGMENT_COULD_NOT_APPLY_POSIX_RIGHTS_TO_SHARED_MEMORY) \
     error(MEPOO__SEGMENT_UNABLE_TO_CREATE_SHARED_MEMORY_OBJECT) \
     error(MEPOO__SEGMENT_INSUFFICIENT_SEGMENT_IDS) \

--- a/iceoryx_posh/include/iceoryx_posh/internal/mepoo/mepoo_segment.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/mepoo/mepoo_segment.hpp
@@ -1,6 +1,7 @@
 // Copyright (c) 2019 by Robert Bosch GmbH. All rights reserved.
 // Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
 // Copyright (c) 2023 by Mathias Kraus <elboberido@m-hias.de>. All rights reserved.
+// Copyright (c) 2024 by Latitude AI. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -35,7 +36,8 @@ template <typename SharedMemoryObjectType = PosixSharedMemoryObject, typename Me
 class MePooSegment
 {
   public:
-    MePooSegment(const MePooConfig& mempoolConfig,
+    MePooSegment(const ShmName_t& name,
+                 const MePooConfig& mempoolConfig,
                  BumpAllocator& managementAllocator,
                  const PosixGroup& readerGroup,
                  const PosixGroup& writerGroup,
@@ -46,15 +48,21 @@ class MePooSegment
 
     MemoryManagerType& getMemoryManager() noexcept;
 
+    /// @brief Get the name of the shared memory segment.
+    /// @details The name is propogated to the shared memory object and used to create
+    ///          the underlying file descriptor at /dev/shm/<name>.
+    const ShmName_t& getSegmentName() const noexcept;
+
     uint64_t getSegmentId() const noexcept;
 
     uint64_t getSegmentSize() const noexcept;
 
   protected:
     SharedMemoryObjectType createSharedMemoryObject(const MePooConfig& mempoolConfig,
-                                                    const PosixGroup& writerGroup) noexcept;
+                                                    const ShmName_t& name) noexcept;
 
   protected:
+    ShmName_t m_name;
     PosixGroup m_readerGroup;
     PosixGroup m_writerGroup;
     uint64_t m_segmentId{0};

--- a/iceoryx_posh/include/iceoryx_posh/internal/mepoo/segment_manager.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/mepoo/segment_manager.hpp
@@ -1,5 +1,6 @@
 // Copyright (c) 2019 by Robert Bosch GmbH. All rights reserved.
 // Copyright (c) 2021 - 2022 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2024 by Latitude AI. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -54,12 +55,12 @@ class SegmentManager
     struct SegmentMapping
     {
       public:
-        SegmentMapping(const ShmName_t& sharedMemoryName,
+        SegmentMapping(const ShmName_t& name,
                        uint64_t size,
                        bool isWritable,
                        uint64_t segmentId,
                        const iox::mepoo::MemoryInfo& memoryInfo = iox::mepoo::MemoryInfo()) noexcept
-            : m_sharedMemoryName(sharedMemoryName)
+            : m_name(name)
             , m_size(size)
             , m_isWritable(isWritable)
             , m_segmentId(segmentId)
@@ -68,7 +69,7 @@ class SegmentManager
         {
         }
 
-        ShmName_t m_sharedMemoryName{""};
+        ShmName_t m_name{""};
         uint64_t m_size{0};
         bool m_isWritable{false};
         uint64_t m_segmentId{0};

--- a/iceoryx_posh/source/runtime/shared_memory_user.cpp
+++ b/iceoryx_posh/source/runtime/shared_memory_user.cpp
@@ -73,7 +73,7 @@ void SharedMemoryUser::openDataSegments(const uint64_t segmentId,
     {
         auto accessMode = segment.m_isWritable ? AccessMode::READ_WRITE : AccessMode::READ_ONLY;
         PosixSharedMemoryObjectBuilder()
-            .name(segment.m_sharedMemoryName)
+            .name(segment.m_name)
             .memorySizeInBytes(segment.m_size)
             .accessMode(accessMode)
             .openMode(OpenMode::OPEN_EXISTING)

--- a/iceoryx_posh/test/moduletests/test_mepoo_segment.cpp
+++ b/iceoryx_posh/test/moduletests/test_mepoo_segment.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) 2019 by Robert Bosch GmbH. All rights reserved.
 // Copyright (c) 2021 - 2022 by Apex.AI Inc. All rights reserved.
 // Copyright (c) 2023 by Mathias Kraus <elboberido@m-hias.de>. All rights reserved.
+// Copyright (c) 2024 by Latitude AI. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -138,7 +139,7 @@ class MePooSegment_test : public Test
     std::unique_ptr<SUT> createSut()
     {
         return std::make_unique<SUT>(
-            mepooConfig, m_managementAllocator, PosixGroup{"iox_roudi_test1"}, PosixGroup{"iox_roudi_test2"});
+            "segment_name", mepooConfig, m_managementAllocator, PosixGroup{"iox_roudi_test1"}, PosixGroup{"iox_roudi_test2"});
     }
 };
 MePooSegment_test::SharedMemoryObject_MOCK::createFct MePooSegment_test::SharedMemoryObject_MOCK::createVerificator;
@@ -160,13 +161,21 @@ TEST_F(MePooSegment_test, SharedMemoryCreationParameter)
                                                                        const iox::OpenMode openMode,
                                                                        const void*,
                                                                        const iox::access_rights) {
-        EXPECT_THAT(f_name, Eq(detail::PosixSharedMemory::Name_t("iox_roudi_test2")));
+        EXPECT_THAT(f_name.c_str(), StrEq(detail::PosixSharedMemory::Name_t("segment_name").c_str()));
         EXPECT_THAT(f_accessMode, Eq(iox::AccessMode::READ_WRITE));
         EXPECT_THAT(openMode, Eq(iox::OpenMode::PURGE_AND_CREATE));
     };
-    SUT sut{mepooConfig, m_managementAllocator, PosixGroup{"iox_roudi_test1"}, PosixGroup{"iox_roudi_test2"}};
+    SUT sut{"segment_name", mepooConfig, m_managementAllocator, PosixGroup{"iox_roudi_test1"}, PosixGroup{"iox_roudi_test2"}};
     MePooSegment_test::SharedMemoryObject_MOCK::createVerificator =
         MePooSegment_test::SharedMemoryObject_MOCK::createFct();
+}
+
+TEST_F(MePooSegment_test, GetSegmentName)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "3508ab9c-a59b-48e4-a3f9-da9c0a2742e6");
+
+    auto sut = createSut();
+    EXPECT_THAT(sut->getSegmentName(), Eq(iox::ShmName_t("segment_name")));
 }
 
 TEST_F(MePooSegment_test, GetSegmentSize)


### PR DESCRIPTION
…ultiple write-access segments to be mapped

## Pre-Review Checklist for the PR Author

1. [ ] Add a second reviewer for complex new features or larger refactorings
1. [ ] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [ ] Tests follow the [best practice for testing][testing]
1. [ ] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [ ] Branch follows the naming format (`iox-123-this-is-a-branch`)
1. [ ] Commits messages are according to this [guideline][commit-guidelines]
    - [ ] Commit messages have the issue ID (`iox-#123 commit text`)
    - [ ] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [ ] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [ ] Relevant issues are linked
1. [ ] Add sensible notes for the reviewer
1. [ ] All checks have passed (except `task-list-completed`)
1. [ ] All touched (C/C++) source code files from `iceoryx_hoofs` are added to `./clang-tidy-diff-scans.txt`
1. [ ] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer

PR #2 in the chain implementing #2128 whose design is described [here](https://github.com/eclipse-iceoryx/iceoryx/pull/2140/files?short_path=b929aa6#diff-b929aa69d30dd941515f8c2d7e162051113bede6fa3b4a06e1aa4693279ce3b8)

## Checklist for the PR Reviewer

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] Code according to our coding style and naming conventions
- [ ] Unit tests have been written for new behavior
- [ ] Public API changes are documented via doxygen
- [ ] Copyright owner are updated in the changed files
- [ ] All touched (C/C++) source code files from `iceoryx_hoofs` have been added to `./clang-tidy-diff-scans.txt`
- [ ] PR title describes the changes

## Post-review Checklist for the PR Author

1. [ ] All open points are addressed and tracked via issues

## References

- Closes **TBD**
